### PR TITLE
PDF URL获取规则修改

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ URL = 'https://github.com/soultoolman/sci-dl'
 EMAIL = 'soultooman@gmail.com'
 AUTHOR = 'soultoolman'
 REQUIRES_PYTHON = '>=3.6.0'
-VERSION = '0.1.1'
+VERSION = '0.1.2'
 
 # What packages are required for this module to be executed?
 REQUIRED = [

--- a/tests/test_sci_dl.py
+++ b/tests/test_sci_dl.py
@@ -11,12 +11,12 @@ def base_url():
 
 @pytest.fixture
 def doi():
-    return '10.1002/9781118445112.stat06003'
+    return '10.3390/cancers13153878'
 
 
 @pytest.fixture
 def pmid():
-    return '33692645'
+    return '34359786'
 
 
 @pytest.fixture()
@@ -40,16 +40,12 @@ class TestProxy(object):
         assert proxy.to_url() == 'socks5://127.0.0.1:1080'
         assert proxy.to_requests() == {
             'http': 'socks5://127.0.0.1:1080',
-            'https': 'socks5://127.0.0.1:1080'
+            'https': 'socks5://127.0.0.1:1080',
         }
 
     def test_user_password(self):
         proxy = sci_dl.Proxy(
-            protocol='http',
-            user='foo',
-            password='bar;',
-            host='localhost',
-            port=10808
+            protocol='http', user='foo', password='bar;', host='localhost', port=10808
         )
         assert proxy.to_url() == 'http://foo:bar%3B@localhost:10808'
 
@@ -63,27 +59,60 @@ class TestSciHub(object):
             sh1.get_matchmaker_url_for_doi(pmid)
 
     def test_get_matchmaker_url_with_doi(self, sh1, doi):
-        url = 'https://sci-hub.se/10.1002/9781118445112.stat06003'
+        url = 'https://sci-hub.se/10.3390/cancers13153878'
         assert sh1.get_matchmaker_url_for_doi(doi) == url
 
     def test_clean_pdf_url(self, sh1):
         pdf_url = sh1.clean_pdf_url(
-            r'\/\/sci-hub.se\/downloads\/2020-04-25\/4d\/10.1111@jgs.16467.pdf#view=FitH'
+            "location.href='/downloads/2021-08-11/f5/gunduz2021.pdf?download=true'"
         )
-        assert pdf_url == 'https://sci-hub.se/downloads/2020-04-25/4d/10.1111@jgs.16467.pdf'
+        assert pdf_url == '/downloads/2021-08-11/f5/gunduz2021.pdf?download=true'
 
     def test_parse_pdf_url1(self, sh1):
         content = """
         <html>
-            <body>
-                <div id="article">
-                    <iframe id="pdf" src="//sci-hub.se/downloads/2020-04-25/4d/10.1111@jgs.16467.pdf#view=FitH">
-                    </iframe>
-                </div>
-            </body>
-        </html>
+        <div id = "roll" onclick="rollup()">◂</div>
+    <div id = "rollback" onclick="rollback()">
+        <img id = "rollimg" src = "/pictures/ravenround.gif">
+    </div>
+    
+    <div id="minu">
+        
+        <a id = "header" href = "//sci-hub.se/">
+            <div>
+                <img id = "logo" src = "/pictures/ravenround.gif">
+            </div>
+            <div>
+                <span id = "sci"><span class = "u">sci</span><br>hub</span><br>
+                <span id = "motto">to open science</span>
+            </div>
+        </a>
+        
+	<div id = "buttons">
+            <button onclick = "location.href='/downloads/2021-08-11/f5/gunduz2021.pdf?download=true'">&darr; save</button>
+	</div>
+
+	<div id = "citation" onclick = "clip(this)">Gunduz, M., Gunduz, E., Tamagawa, S., Enomoto, K., & Hotomi, M. (2021). <i>Cancer Stem Cells in Oropharyngeal Cancer. Cancers, 13(15), 3878.</i> doi:10.3390/cancers13153878&nbsp;</div>
+
+        <div id = "doi">
+            10.3390/cancers13153878
+        </div>
+        
+        <div id ="versions">
+            
+        </div>
+        
+    </div>
+
+    <div id="article">
+        <embed type="application/pdf" src="/downloads/2021-08-11/f5/gunduz2021.pdf#navpanes=0&view=FitH" id = "pdf"></embed>
+    </div>
+    </html>
         """
-        assert sh1.parse_pdf_url(content) == 'https://sci-hub.se/downloads/2020-04-25/4d/10.1111@jgs.16467.pdf'
+        assert (
+            sh1.parse_pdf_url(content)
+            == 'https://sci-hub.se/downloads/2021-08-11/f5/gunduz2021.pdf?download=true'
+        )
 
     def test_parse_pdf_url2(self, sh1):
         content = """


### PR DESCRIPTION
sci-hub网站有更新，原有的PDF URL获取规则已不能使用，
已加入了新的获取方式